### PR TITLE
Disable Exim4 service

### DIFF
--- a/stages/04-Wifibroadcast/03-run-chroot.sh
+++ b/stages/04-Wifibroadcast/03-run-chroot.sh
@@ -24,6 +24,7 @@ sudo systemctl disable triggerhappy.service
 sudo systemctl disable ser2net.service
 sudo systemctl disable systemd-timesyncd.service
 sudo systemctl disable hciuart.service
+sudo systemctl disable exim4.service
 
 #Mask difficult to disable services
 systemctl stop systemd-journald.service


### PR DESCRIPTION
eliminates error messages on boot and just one less thing running in the background