### PR TITLE
Optomizes for Pi2-3b+ (Removes dual framebuffer for problem-free setup)

### DIFF
--- a/stages/04-Wifibroadcast/FILES/overlay/boot/config.txt
+++ b/stages/04-Wifibroadcast/FILES/overlay/boot/config.txt
@@ -83,7 +83,7 @@ max_framebuffers=2
 # Enable audio (loads snd_bcm2835)
 dtparam=audio=on
 
-gpu_mem=256
+gpu_mem=128
 
 # force gpu to run in turbo mode for less latency and jitter
 force_turbo=1
@@ -143,6 +143,6 @@ fixup_file=1to3bup_x.dat
 start_file=1to3b_x.elf
 fixup_file=1to3bup_x.dat
 [pi3+]
-start_file=1to3b_x.elf
-fixup_file=1to3bup_x.dat
+start_file=start_x.elf
+fixup_file=fixup_x.dat
 


### PR DESCRIPTION
*This removes the dual framebuffer [pi3+] code at the bottom and sets GPU Mem back to 128MB In order to maintain full functionality for Pi3 A+ boards with limited memory.  If users want dual framebuffer (Mirror DSI display to HDMI Port) they simply need to change the following.... 
*NOTE*
These changes are not recommended using Pi3 Model A+ on the ground....

1.)
CHANGE THIS:
gpu_mem=128

TO THIS:
gpu_mem=256

AND:

2.)
THIS:
[pi3+]
start_file=start_x.elf
fixup_file=fixup_x.dat

TO THIS:
[pi3+]
start_file=1to3b_x.elf
fixup_file=1to3bup_x.dat