### PR TITLE
Changed Joystick Update to "10" (50hz) default

### DIFF
--- a/stages/04-Wifibroadcast/FILES/overlay/boot/joyconfig.txt
+++ b/stages/04-Wifibroadcast/FILES/overlay/boot/joyconfig.txt
@@ -28,6 +28,6 @@
 #define AXIS7_INITIAL 1000
 
 // 3 = 6ms (167Hz), 4 = 8ms (125Hz), 5 = 10ms (100Hz), 6 = 12ms (83Hz), 7 = 14ms (71Hz), 8 = 16ms (63Hz), 9 = 18ms (56Hz), 10 = 20ms (50Hz) 
-#define UPDATE_NTH_TIME 8 
+#define UPDATE_NTH_TIME 10
 #define TRANSMISSIONS 2
 


### PR DESCRIPTION
This sets the joystick Update to 10 for minimizing Pi Zero CPU.  It can be set lower especially with Pi2/3 air but 10 appears to have equal performance and matches the recently released 3/21 iso image release.