### PR TITLE
txpower_atheros - Script to set txpower for Atheros and Realtek cards

### DIFF
--- a/stages/04-Wifibroadcast/FILES/overlay/usr/local/bin/txpower_atheros
+++ b/stages/04-Wifibroadcast/FILES/overlay/usr/local/bin/txpower_atheros
@@ -2,7 +2,7 @@
 
 usage(){
     echo
-    echo "txpower_atheros - Script to set txpower for Atheros cards"
+    echo "txpower_atheros - Script to set txpower for Atheros and Realtek cards"
     echo
     echo "Usage: $0 <txpower> (default 58, minimum 1, maximum 63)"
     echo
@@ -16,6 +16,10 @@ usage(){
 mount -o remount,rw /
 mv /etc/modprobe.d/ath9k_hw.conf /etc/modprobe.d/ath9k_hw.conf.old
 sed -r -e's/txpower=[^ ]+/txpower='$1'/g' /etc/modprobe.d/ath9k_hw.conf.old > /etc/modprobe.d/ath9k_hw.conf
+mv /etc/modprobe.d/rtl88XXau.conf /etc/modprobe.d/rtl88XXau.conf.old
+sed -r -e's/rtw_tx_pwr_idx_override=[^ ]+/rtw_tx_pwr_idx_override='$1'/g' /etc/modprobe.d/rtl88XXau.conf.old > /etc/modprobe.d/rtl88XXau.conf
+mv /etc/modprobe.d/rtl8812au.conf /etc/modprobe.d/rtl8812au.conf.old
+sed -r -e's/rtw_tx_pwr_idx_override=[^ ]+/rtw_tx_pwr_idx_override='$1'/g' /etc/modprobe.d/rtl8812au.conf.old > /etc/modprobe.d/rtl88X12au.conf
 sync
 echo
 echo "txpower set to $1. You may power-off now or type \"reboot\" to restart"

--- a/stages/04-Wifibroadcast/FILES/overlay/usr/local/bin/txpower_atheros
+++ b/stages/04-Wifibroadcast/FILES/overlay/usr/local/bin/txpower_atheros
@@ -19,7 +19,7 @@ sed -r -e's/txpower=[^ ]+/txpower='$1'/g' /etc/modprobe.d/ath9k_hw.conf.old > /e
 mv /etc/modprobe.d/rtl88XXau.conf /etc/modprobe.d/rtl88XXau.conf.old
 sed -r -e's/rtw_tx_pwr_idx_override=[^ ]+/rtw_tx_pwr_idx_override='$1'/g' /etc/modprobe.d/rtl88XXau.conf.old > /etc/modprobe.d/rtl88XXau.conf
 mv /etc/modprobe.d/rtl8812au.conf /etc/modprobe.d/rtl8812au.conf.old
-sed -r -e's/rtw_tx_pwr_idx_override=[^ ]+/rtw_tx_pwr_idx_override='$1'/g' /etc/modprobe.d/rtl8812au.conf.old > /etc/modprobe.d/rtl88X12au.conf
+sed -r -e's/rtw_tx_pwr_idx_override=[^ ]+/rtw_tx_pwr_idx_override='$1'/g' /etc/modprobe.d/rtl8812au.conf.old > /etc/modprobe.d/rtl8812au.conf
 sync
 echo
 echo "txpower set to $1. You may power-off now or type \"reboot\" to restart"


### PR DESCRIPTION
The txpower_atheros command modifies the rtl8812au and rtl88xxau transmit power simultaneously