### PR TITLE
Check base image instead of download it again every time

### DIFF
--- a/stages/01-Baseimage/00-run.sh
+++ b/stages/01-Baseimage/00-run.sh
@@ -1,12 +1,19 @@
 # Do this to the WORK folder of this stage
 pushd ${STAGE_WORK_DIR}
 
-log "Clear any previous images"
-rm *.zip
-rm *.img
+log "Check any previous images"
+# check for matching sha256 hash instead of downloading it again
+if echo "`wget -qO- ${BASE_IMAGE_URL}/${BASE_IMAGE}.zip.sha256`" | sha256sum -c -
+then
+    rm *.img  # must be deleted every time because of no way to check
+    log "Raspbian base Image already downloaded"
+else
+    rm *.zip
+    rm *.img
 
-log "Download Raspbian base Image"
-wget $BASE_IMAGE_URL/$BASE_IMAGE".zip"
+    log "Download Raspbian base Image"
+    wget $BASE_IMAGE_URL/$BASE_IMAGE".zip"
+fi
 
 log "Unzip"
 unzip $BASE_IMAGE".zip"


### PR DESCRIPTION
Check the SHA of the image, instead of redownloading it.