### PR TITLE
Disable i2c_vc in config.txt

### DIFF
--- a/stages/05-Wifibroadcast/FILES/overlay/boot/config.txt
+++ b/stages/05-Wifibroadcast/FILES/overlay/boot/config.txt
@@ -121,7 +121,7 @@ usb_mdio=0x7000
 # uncomment for I2C
 #dtparam=i2c1=on
 dtparam=i2c_arm=on
-dtparam=i2c_vc=on
+#dtparam=i2c_vc=on
 #
 # uncomment for SPI
 #dtparam=spi=on


### PR DESCRIPTION
When the camera, touchscreen, or hats with EEPROMs are in use, only the GPU is allowed to use the other i2c bus that `i2c_vc` controls access to. Even enabling access to it from the ARM side can cause serious bugs (freezes the entire touchscreen due to incorrect interrupt routing).

It isn't needed on the ground side at all, and only the Innomaker camera needs it on the air side.