### PR TITLE
fix missing popd statement, breaks cmavnode compilation

### DIFF
--- a/stages/04-Support/00-run.sh
+++ b/stages/04-Support/00-run.sh
@@ -24,6 +24,7 @@ sudo git submodule update --init
 #fix missing pymavlink
 pushd modules/mavlink
 sudo git clone --recurse-submodules https://github.com/user1321/pymavlink
+popd
 
 popd
 


### PR DESCRIPTION
Looks like a simple omission, I've been building images with this added for weeks and everything seems to work fine.

Without it, the next build command that builds cmavnode is in the wrong directory, so building it fails. 

Nothing else is affected because the next script immediately changes directory when it starts.