### PR TITLE
Add git commit of builder/open.hd repo to images

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -95,6 +95,12 @@ GIT_KERNEL_SHA1=$(cat $WORK_DIR/infofile | grep -Po '\b(Kernel: https:\/\/github
 KERNEL_VERSION_V7=$(cat $WORK_DIR/infofile | grep -Po '\b(Uname string: Linux version )\K(?<price>[^\ ]+)')
 KERNEL_VERSION=${KERNEL_VERSION_V7%"-v7+"}"+"
 
+# used in the stage 5 scripts to place a version file inside the image, and below after the
+# stages have run, in the name of the image itself
+BUILDER_VERSION=$(git describe --always --tags)
+export BUILDER_VERSION
+
+
 export BASE_DIR
 
 export CLEAN
@@ -134,9 +140,11 @@ for STAGE_DIR in "${BASE_DIR}/stages/"*; do
 	fi
 done
 
+# rename the image according to the build date, the builder/openhd repo versions
+OPENHD_VERSION=$(cat ${WORK_DIR}/openhd_version.txt)
 if [ -f "${PREV_WORK_DIR}/IMAGE.img" ]; then
 	mkdir -p "${DEPLOY_DIR}" || true
-	cp "${PREV_WORK_DIR}/IMAGE.img" "${DEPLOY_DIR}/${IMG_NAME}-${IMG_DATE}.img"
+	cp "${PREV_WORK_DIR}/IMAGE.img" "${DEPLOY_DIR}/${IMG_NAME}-${IMG_DATE}-${OPENHD_VERSION}.img"
 fi
 
 #  Clean up SKIP_STEP files since we finished the build

--- a/stages/05-Wifibroadcast/01-run.sh
+++ b/stages/05-Wifibroadcast/01-run.sh
@@ -14,7 +14,17 @@ log "Download all Open.HD Sources"
 sudo git clone -b development https://github.com/HD-Fpv/Open.HD.git
 pushd Open.HD
 sudo git submodule update --init
+OPENHD_VERSION=$(git describe --always --tags)
+export OPENHD_VERSION
 popd
+
+# store the commit used for the Open.HD repo as we as the builder inside the image
+# to allow tracing problems and changes back to the source, even if the image is renamed
+echo ${OPENHD_VERSION} > ${MNT_DIR}/openhd_version.txt
+echo ${BUILDER_VERSION} > ${MNT_DIR}/builder_version.txt
+# copy the Open.HD repo version back down to the work folder so build.sh can retrieve it and use it
+# in the name of the image being built
+cp ${MNT_DIR}/openhd_version.txt ${STAGE_WORK_DIR}/../
 
 log "Download OpenVG"
 sudo mv Open.HD/openvg/ openvg/


### PR DESCRIPTION
With these changes:

1) There will be a `openhd_version.txt` and `builder_version.txt` in the root of the image containing the output of `git describe --always --tags`

2) The image itself will now be automatically named using the Open.HD repo version (not both, because adding both would be confusing, see below for a solution to that)

#### Examples of the image names this PR produces

If there's no tagged release in the entire repo (like now) and the hash of the current commit is 2255634: 

`Open.HD-2019-11-25-2255634.img`

If there's a tagged release in the repo and it is attached to the current commit, or the person/CI building it has explicitly checked out a particular tag (git checkout v2.1.0):

 `Open.HD-2019-11-25-v2.1.0.img`

If there have been 3 commits added to the repo since the last tagged release and the hash of the current commit is 2255634: 

`Open.HD-2019-11-25-v2.1.0-3-2255634.img`

---------------------------

To keep everything properly version controlled without putting multiple versions in the image name, we can either:

1) Make the Open.HD repo a submodule of the builder repo

A particular commit in the builder repo is then linked to a particular commit in the Open.HD repo. If you know that a particular image was built with v2.1.0 of the builder, then you can easily look at the builder repo to see which version of the Open.HD repo was used.

This requires anyone working with the builder to know how to update git submodules and properly commit changes to them in the parent repo (not hard, just use a git GUI client).

2) Put a hash from a particular commit in the Open.HD repo into the `config` file in the root of the builder repo, and have the builder scripts checkout that commit when cloning the Open.HD repo in stage 5.

Option 2 is going to be easier for people who aren't familiar with git. In that case you would change that `config` file to update the version of the Open.HD repo rather than updating submodules.

Once we do one of those things, we can then put just the version of the builder in the name of images because that alone will identify the entire build.
