### PR TITLE
Add config option for Open.HD repo/branch

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -112,6 +112,8 @@ export GIT_KERNEL_SHA1
 export KERNEL_VERSION
 export KERNEL_VERSION_V7
 export APT_PROXY
+export OPENHD_REPO
+export OPENHD_BRANCH
 
 export STAGE
 export STAGE_DIR

--- a/config
+++ b/config
@@ -10,4 +10,6 @@ BASE_IMAGE="2018-10-09-raspbian-stretch-lite"
 # Amount of cores to use for compilation on host machine
 J_CORES=12
 
+OPENHD_REPO=https://github.com/Hd-Fpv/Open.HD.git
+OPENHD_BRANCH=master
 

--- a/stages/05-Wifibroadcast/01-run.sh
+++ b/stages/05-Wifibroadcast/01-run.sh
@@ -11,8 +11,9 @@ pushd GIT
 MNT_DIR="${STAGE_WORK_DIR}/mnt"
 
 log "Download all Open.HD Sources"
-sudo git clone -b master https://github.com/HD-Fpv/Open.HD.git
+sudo git clone -b master ${OPENHD_REPO}
 pushd Open.HD
+git checkout ${OPENHD_BRANCH}
 sudo git submodule update --init
 OPENHD_VERSION=$(git describe --always --tags)
 export OPENHD_VERSION


### PR DESCRIPTION
With this you can change which repository and branch (or tag) the
builder will use in stage 5 for the Open.HD files. Just edit the `config` file
in the root of the builder and change the `OPENHD_REPO` and `OPENHD_BRANCH`
variables to point wherever you wish.

This makes it easier for people to test images that require Open.HD
code that is not yet in master or in another repo entirely.