### PR TITLE
Fix bash variable expansion in 01-Baseimage/00-run

### DIFF
--- a/stages/01-Baseimage/00-run.sh
+++ b/stages/01-Baseimage/00-run.sh
@@ -16,10 +16,10 @@ else
 fi
 
 log "Unzip"
-unzip $BASE_IMAGE".zip"
+unzip ${BASE_IMAGE}.zip
 
 log "Rename to IMAGE.img"
-mv $BASE_IMAGE".img" "IMAGE.img"
+mv ${BASE_IMAGE}.img IMAGE.img
 
 # return
 popd


### PR DESCRIPTION
This is a simple style fix, ".zip" doesn't need to be quoted and it's generally a good idea to wrap variables in brackets by default as it's required in some cases (though not here)