### PR TITLE
Fix broadcom library symlinks and pkgconfig files

### DIFF
--- a/stages/04-Support/00-run-chroot.sh
+++ b/stages/04-Support/00-run-chroot.sh
@@ -1,0 +1,17 @@
+# This runs in context if the image (CHROOT)
+# Any native compilation can be done here
+# Do not use log here, it will end up in the image
+
+#!/bin/bash
+
+# fix broadcom opengl  library names without breaking anything else
+ln -sf /opt/vc/lib/libbrcmEGL.so /opt/vc/lib/libEGL.so
+ln -sf /opt/vc/lib/libEGL.so /opt/vc/lib/libEGL.so.1
+ln -sf /opt/vc/lib/libbrcmGLESv2.so /opt/vc/lib/libGLESv2.so
+ln -sf /opt/vc/lib/libbrcmGLESv2.so /opt/vc/lib/libGLESv2.so.2
+ln -sf /opt/vc/lib/libbrcmOpenVG.so /opt/vc/lib/libOpenVG.so
+ln -sf /opt/vc/lib/libbrcmWFC.so /opt/vc/lib/libWFC.so
+
+ln -sf /opt/vc/lib/pkgconfig/brcmegl.pc    /opt/vc/lib/pkgconfig/egl.pc
+ln -sf /opt/vc/lib/pkgconfig/brcmglesv2.pc /opt/vc/lib/pkgconfig/glesv2.pc
+ln -sf /opt/vc/lib/pkgconfig/brcmvg.pc     /opt/vc/lib/pkgconfig/vg.pc


### PR DESCRIPTION
This is necessary to allow software (like Qt) that uses GLESv2 or EGL to build correctly. 

Raspbian changed the name of these libraries to avoid a conflict with the Mesa versions in `usr/lib/arm-linux-gnueabihf`, but not all 3rd party build systems have adapted.