### PR TITLE
Add apt clean and move final autoremove in stage 3

### DIFF
--- a/stages/03-Packages/00-run-chroot.sh
+++ b/stages/03-Packages/00-run-chroot.sh
@@ -98,10 +98,12 @@ DEBIAN_FRONTEND=noninteractive sudo apt-get -yq purge curl
 DEBIAN_FRONTEND=noninteractive sudo apt-get -yq purge iptables
 DEBIAN_FRONTEND=noninteractive sudo apt-get -yq purge triggerhappy
 
-# Clean Up
-DEBIAN_FRONTEND=noninteractive sudo apt-get -yq autoremove
 
 # Python essentials for mavlink router autoconf
 sudo pip install future
 #Python3 GPIO
 sudo apt-get -y install python3-rpi.gpio
+
+# Clean Up
+DEBIAN_FRONTEND=noninteractive sudo apt-get -yq clean
+DEBIAN_FRONTEND=noninteractive sudo apt-get -yq autoremove


### PR DESCRIPTION
This adds a final step to stage3 that will clean up any temporarily downloaded package files, apt keeps them by default.

It also moves the autoremove step down to the very end since there is another package being installed after the current location.

It should save space on the final image.