### PR TITLE
dont delete kernel source every build, just reset tree

### DIFF
--- a/stages/02-Kernel/00-run.sh
+++ b/stages/02-Kernel/00-run.sh
@@ -3,13 +3,15 @@ set -e
 # Do this to the WORK folder of this stage
 pushd ${STAGE_WORK_DIR}
 
-log "Remove previous Kernel"
-rm -r linux || true
-
-log "Download the Raspberry Pi Kernel"
-git clone --depth=100 -b ${PI_KERNEL_BRANCH} ${PI_KERNEL_REPO}
+if [ ! -d "linux" ]; then
+    log "Download the Raspberry Pi Kernel"
+    git clone --depth=100 -b ${PI_KERNEL_BRANCH} ${PI_KERNEL_REPO}
+fi
 
 pushd linux
+git reset --hard
+git pull
+
 # Switch to specific commit
 git checkout $GIT_KERNEL_SHA1
 


### PR DESCRIPTION
This is similar to the way some other git repos are currently being used in other parts of the builder, and saves a ton of bandwidth and time during repeat builds.