### PR TITLE
Add cleanup script for failed builds

### DIFF
--- a/clean-fail.sh
+++ b/clean-fail.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+
+for stage in 01-Baseimage 02-Kernel 03-Packages 04-Support 05-Wifibroadcast
+do
+    umount work/$stage/mnt/boot
+    umount work/$stage/mnt/dev/pts
+    umount work/$stage/mnt/dev
+    umount work/$stage/mnt/etc/resolv.conf 
+    umount work/$stage/mnt/proc
+    umount work/$stage/mnt/sys
+    umount work/$stage/mnt/
+done
+
+losetup -D


### PR DESCRIPTION
This unmounts and unmaps any loop devices that have been used during a build. 

When a build fails or is cancelled, the loop device and the mountpoint will stick around unless manually removed, and that can cause build problems during a repeat build if the stages are not all reset.

In addition, images that are deleted while still mapped with `losetup` will actually stick around on the filesystem invisibly and take up tons of space, which can cause the local filesystem to become full until they are unmapped or until the next reboot.